### PR TITLE
fix LinkedList not thread-safe bug.

### DIFF
--- a/aavt/src/main/java/com/wuwang/aavt/av/VideoCapture.java
+++ b/aavt/src/main/java/com/wuwang/aavt/av/VideoCapture.java
@@ -138,6 +138,7 @@ public class VideoCapture {
 
     public void stopRecord(){
         encoder.close();
+        muxer.close();
     }
 
 

--- a/aavt/src/main/java/com/wuwang/aavt/gl/BaseFilter.java
+++ b/aavt/src/main/java/com/wuwang/aavt/gl/BaseFilter.java
@@ -76,6 +76,7 @@ public abstract class BaseFilter implements Renderer {
 
     private FrameBuffer mFrameTemp;
     private final LinkedList<Runnable> mTasks=new LinkedList<>();
+    private final Object Lock = new Object();
 
     protected BaseFilter(Resources resource,String vertex,String fragment){
         this.mRes=resource;
@@ -203,9 +204,11 @@ public abstract class BaseFilter implements Renderer {
     }
 
     protected void onTaskExec(){
+      synchronized (Lock) {
         while (!mTasks.isEmpty()){
             mTasks.removeFirst().run();
         }
+      }
     }
 
     protected void onUseProgram(){
@@ -229,7 +232,9 @@ public abstract class BaseFilter implements Renderer {
     }
 
     public void runOnGLThread(Runnable runnable){
+      synchronized (Lock) {
         mTasks.addLast(runnable);
+      }
     }
 
     /**

--- a/aavt/src/main/java/com/wuwang/aavt/media/SurfaceShower.java
+++ b/aavt/src/main/java/com/wuwang/aavt/media/SurfaceShower.java
@@ -37,10 +37,18 @@ public class SurfaceShower implements IObserver<RenderBean> {
     private int mHeight;
     private int mMatrixType= MatrixUtils.TYPE_CENTERCROP;
     private OnDrawEndListener mListener;
+    private RenderBean mBean;
 
     public void setOutputSize(int width,int height){
         this.mWidth=width;
         this.mHeight=height;
+    }
+
+    private void clearSurface() {
+        if(mShowSurface!=null){
+            mBean.egl.destroySurface(mShowSurface);
+            mShowSurface = null;
+        }
     }
 
     /**
@@ -49,6 +57,7 @@ public class SurfaceShower implements IObserver<RenderBean> {
      */
     public void setSurface(Object surface){
         this.mSurface=surface;
+        clearSurface();
     }
 
     /**
@@ -69,11 +78,11 @@ public class SurfaceShower implements IObserver<RenderBean> {
 
     @Override
     public void onCall(RenderBean rb) {
-        if(rb.endFlag&&mShowSurface!=null){
-            rb.egl.destroySurface(mShowSurface);
-            mShowSurface=null;
+        if(rb.endFlag){
+            clearSurface();
         }else if(isShow&&mSurface!=null){
             if(mShowSurface==null){
+                mBean = rb;
                 mShowSurface=rb.egl.createWindowSurface(mSurface);
                 mFilter=new LazyFilter();
                 mFilter.create();

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
 
@@ -17,6 +18,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/examples/src/main/java/com/wuwang/aavt/examples/CameraRecorderActivity.java
+++ b/examples/src/main/java/com/wuwang/aavt/examples/CameraRecorderActivity.java
@@ -55,7 +55,7 @@ public class CameraRecorderActivity extends AppCompatActivity{
             public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
                 mCamera.setProperty(VideoCapture.KEY_PREVIEW_WIDTH,width);
                 mCamera.setProperty(VideoCapture.KEY_PREVIEW_HEIGHT,height);
-                mCamera.open(1);
+                mCamera.open(0);
                 mCamera.setPreviewSurface(holder.getSurface());
                 mCamera.startPreview();
                 isPreviewOpen=true;
@@ -93,7 +93,7 @@ public class CameraRecorderActivity extends AppCompatActivity{
                             Intent v=new Intent(Intent.ACTION_VIEW);
                             v.setDataAndType(Uri.parse(tempPath),"video/mp4");
                             if(v.resolveActivity(getPackageManager()) != null){
-                                startActivity(v);
+                                //startActivity(v);
                             }else{
                                 Toast.makeText(CameraRecorderActivity.this,
                                         "无法找到默认媒体软件打开:"+tempPath, Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
使用watermark filte 的setMarkPosition 達成跑馬燈效果, 會在幾小時發生如下錯誤:
04-01 09:51:51.114 21662 21689 E AndroidRuntime: FATAL EXCEPTION: Thread-3
04-01 09:51:51.114 21662 21689 E AndroidRuntime: Process: com.wuwang.aavt.examples, PID: 21662
04-01 09:51:51.114 21662 21689 E AndroidRuntime: java.util.NoSuchElementException
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at java.util.LinkedList.removeFirst(LinkedList.java:270)
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at com.wuwang.aavt.gl.BaseFilter.onTaskExec(BaseFilter.java:207)
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at com.wuwang.aavt.gl.BaseFilter.onUseProgram(BaseFilter.java:213)
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at com.wuwang.aavt.gl.BaseFilter.draw(BaseFilter.java:181)
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at com.wuwang.aavt.gl.BaseFilter.drawToTexture(BaseFilter.java:194)
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at com.wuwang.aavt.gl.GroupFilter.draw(GroupFilter.java:108)
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at com.wuwang.aavt.media.WrapRenderer.draw(WrapRenderer.java:82)
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at com.wuwang.aavt.media.VideoSurfaceProcessor.glRun(VideoSurfaceProcessor.java:170)
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at com.wuwang.aavt.media.VideoSurfaceProcessor.access$000(VideoSurfaceProcessor.java:42)
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at com.wuwang.aavt.media.VideoSurfaceProcessor$1.run(VideoSurfaceProcessor.java:73)
04-01 09:51:51.114 21662 21689 E AndroidRuntime:        at java.lang.Thread.run(Thread.java:761)

這是因為父類別 BaseFilter中的 LinkedList沒有 thread-safe, 建議加上 synchronized才不會發生exception.